### PR TITLE
Add a task in Portcullis Routine

### DIFF
--- a/src/main/java/com/lynbrookrobotics/sixteen/config/constants/IntakeArmConstants.java
+++ b/src/main/java/com/lynbrookrobotics/sixteen/config/constants/IntakeArmConstants.java
@@ -16,6 +16,7 @@ public class IntakeArmConstants {
   public static final double LOW_POSITON_PORTCULLIS = 0.0;
   public static final double TRANSPORT_SETPOINT = 0.0;
 
+  public static final double DRIVING_DISTANCE_TO_PORTCULLIS = 0.0;
 
   public static final double LOW_POSITION_PORTCULLIS = 0.0;
 

--- a/src/main/java/com/lynbrookrobotics/sixteen/tasks/defenses/PortcullisRoutine.java
+++ b/src/main/java/com/lynbrookrobotics/sixteen/tasks/defenses/PortcullisRoutine.java
@@ -26,6 +26,12 @@ public class PortcullisRoutine {
         intakeArm,
         robotHardware
     ).then(
+        new DriveRelative(robotHardware,
+            IntakeArmConstants.DRIVING_DISTANCE_TO_PORTCULLIS,
+            IntakeArmConstants.DRIVING_DISTANCE_TO_PORTCULLIS,
+            drivetrain
+        )
+    ).then(
         new MoveIntakeArmToAngle(
             IntakeArmConstants.HIGH_POSITION_PORTCULLIS,
             intakeArm,


### PR DESCRIPTION
This task which makes the drive train move to the right spot, after moving the intake to the low position.
